### PR TITLE
fix: redirect www a non-www para evitar error de CORS

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "www.exactamente.com.ar" }],
+      "destination": "https://exactamente.com.ar/:path*",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
Agrega `vercel.json` con un redirect 301 permanente de `www.exactamente.com.ar` a `exactamente.com.ar`.

**Problema:** el backend tiene `exactamente.com.ar` en `CORS_ORIGIN` pero las visitas a `www.exactamente.com.ar` llegan con un origin distinto, bloqueando todos los fetches a la API.

**Solución:** Vercel intercepta cualquier request con host `www.exactamente.com.ar` y redirige antes de que llegue al frontend, estableciendo `exactamente.com.ar` como dominio canónico.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added permanent redirect configuration for incoming requests to ensure consistent domain handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/exactamente-ar/exactamente-frontend/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->