### PR TITLE
feat(upload): add examDay field for final type

### DIFF
--- a/src/features/upload/components/UploadForm.tsx
+++ b/src/features/upload/components/UploadForm.tsx
@@ -14,6 +14,11 @@ const YEARS = Array.from({ length: 2026 - 2000 + 1 }, (_, i) => {
   return { value: String(y), label: String(y) };
 });
 
+const DAYS = Array.from({ length: 31 }, (_, i) => ({
+  value: String(i + 1),
+  label: String(i + 1),
+}));
+
 const MONTHS = [
   { value: '1', label: 'Enero' },
   { value: '2', label: 'Febrero' },
@@ -62,6 +67,7 @@ const UploadForm: React.FC<UploadFormProps> = ({
   onSubtypeChange,
   onExamYearChange,
   onExamMonthChange,
+  onExamDayChange,
   onTopicChange,
   onNotesChange,
   onFileChange,
@@ -165,6 +171,19 @@ const UploadForm: React.FC<UploadFormProps> = ({
           />
         </FormField>
       </div>
+
+      {formData.type === 'final' && (
+        <FormField label='Día' required>
+          <SelectInput
+            name='examDay'
+            value={formData.examDay}
+            onValueChange={onExamDayChange}
+            options={DAYS}
+            placeholder='Seleccioná el día'
+            error={errors.examDay}
+          />
+        </FormField>
+      )}
 
       {(formData.type === 'parcial' || formData.type === 'final') && (
         <FormField label='Tema'>

--- a/src/features/upload/components/UploadSection.tsx
+++ b/src/features/upload/components/UploadSection.tsx
@@ -54,6 +54,7 @@ function UploadSectionInner() {
     onSubtypeChange,
     onExamYearChange,
     onExamMonthChange,
+    onExamDayChange,
     onTopicChange,
     onNotesChange,
     onFileChange,
@@ -131,6 +132,7 @@ function UploadSectionInner() {
             onSubtypeChange={onSubtypeChange}
             onExamYearChange={onExamYearChange}
             onExamMonthChange={onExamMonthChange}
+            onExamDayChange={onExamDayChange}
             onTopicChange={onTopicChange}
             onNotesChange={onNotesChange}
             onFileChange={onFileChange}

--- a/src/features/upload/hooks/useUploadForm.ts
+++ b/src/features/upload/hooks/useUploadForm.ts
@@ -15,6 +15,7 @@ const INITIAL_STATE: UploadFormState = {
   subtype: '',
   examYear: '',
   examMonth: '',
+  examDay: '',
   topic: '',
   notes: '',
   file: null,
@@ -90,6 +91,7 @@ export function useUploadForm(initialValues?: InitialValues) {
     if (formData.type === 'parcial' && !formData.subtype) newErrors.subtype = 'Seleccioná el subtipo';
     if (!formData.examYear) newErrors.examYear = 'Seleccioná el año del examen';
     if (!formData.examMonth) newErrors.examMonth = 'Seleccioná el mes del examen';
+    if (formData.type === 'final' && !formData.examDay) newErrors.examDay = 'Ingresá el día del examen';
     if (formData.fileMode === 'pdf' && !formData.file) newErrors.file = 'Seleccioná un archivo PDF';
     if (formData.fileMode === 'images' && formData.imageFiles.length === 0) newErrors.file = 'Agregá al menos una imagen';
     setErrors(newErrors);
@@ -121,6 +123,7 @@ export function useUploadForm(initialValues?: InitialValues) {
           subtype: formData.subtype || undefined,
           examYear: formData.examYear ? Number(formData.examYear) : undefined,
           examMonth: formData.examMonth ? Number(formData.examMonth) : undefined,
+          examDay: formData.type === 'final' && formData.examDay ? Number(formData.examDay) : undefined,
           topic: formData.topic && formData.topic !== 'none' ? Number(formData.topic) : undefined,
           notes: formData.notes || undefined,
         },
@@ -192,13 +195,14 @@ export function useUploadForm(initialValues?: InitialValues) {
     },
     onSubjectChange: (v: string) => updateField('subjectId', v),
     onTypeChange: (v: string) => {
-      setFormData((prev) => ({ ...prev, type: v as UploadFormState['type'], title: '', subtype: '' }));
-      setErrors((prev) => ({ ...prev, type: undefined, title: undefined, subtype: undefined }));
+      setFormData((prev) => ({ ...prev, type: v as UploadFormState['type'], title: '', subtype: '', examDay: '' }));
+      setErrors((prev) => ({ ...prev, type: undefined, title: undefined, subtype: undefined, examDay: undefined }));
     },
     onTitleChange: (v: string) => updateField('title', v),
     onSubtypeChange: (v: string) => updateField('subtype', v),
     onExamYearChange: (v: string) => updateField('examYear', v),
     onExamMonthChange: (v: string) => updateField('examMonth', v),
+    onExamDayChange: (v: string) => updateField('examDay', v),
     onTopicChange: (v: string) => updateField('topic', v),
     onNotesChange: (v: string) => updateField('notes', v),
     onFileChange: (f: File | null) => updateField('file', f),

--- a/src/features/upload/types/form.ts
+++ b/src/features/upload/types/form.ts
@@ -7,6 +7,7 @@ export interface UploadFormState {
   subtype: string;
   examYear: string;
   examMonth: string;
+  examDay: string;
   topic: string;
   notes: string;
   file: File | null;
@@ -23,6 +24,7 @@ export interface UploadFormErrors {
   subtype?: string;
   examYear?: string;
   examMonth?: string;
+  examDay?: string;
   file?: string;
 }
 
@@ -44,6 +46,7 @@ export interface UploadFormProps {
   onSubtypeChange: (value: string) => void;
   onExamYearChange: (value: string) => void;
   onExamMonthChange: (value: string) => void;
+  onExamDayChange: (value: string) => void;
   onTopicChange: (value: string) => void;
   onNotesChange: (value: string) => void;
   onFileChange: (file: File | null) => void;

--- a/src/shared/services/api.ts
+++ b/src/shared/services/api.ts
@@ -324,6 +324,7 @@ export async function uploadResource(
     subtype?: string;
     examYear?: number;
     examMonth?: number;
+    examDay?: number;
     topic?: number;
     notes?: string;
   },
@@ -338,6 +339,7 @@ export async function uploadResource(
     form.append('examMonth', String(data.examMonth));
     if (data.title) form.append('title', data.title);
     if (data.subtype) form.append('subtype', data.subtype);
+    if (data.examDay != null) form.append('examDay', String(data.examDay));
     if (data.topic != null) form.append('topic', String(data.topic));
     if (data.notes) form.append('notes', data.notes);
 


### PR DESCRIPTION
## Summary

- Adds a required **Día** selector (1–31) to the upload form, visible only when `type === 'final'`
- Maps to the new `examDay` field added in the backend (`POST /api/v1/resources`)
- Validates that the field is filled before submission
- Clears the field when the user switches away from the `final` type

## Test plan

- [x] Select type "Final" → "Día" selector appears after "Mes"
- [x] Select type "Resumen" or "Parcial" → "Día" selector is hidden
- [x] Submit a final without selecting a day → validation error shown
- [x] Submit a final with all fields → `examDay` included in FormData sent to backend
- [x] `pnpm build` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exam day selection is now available for final exam uploads. Users can choose an exam day (1–31) when uploading final exam resources. The field is conditionally displayed for final exams only, validated before upload, and sent to the backend along with other exam details to maintain complete scheduling information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->