### PR TITLE
feat(filters): auto-select plan 2024 by default for Ing. en Sistemas

### DIFF
--- a/src/features/home/components/subjects/SubjectsView.tsx
+++ b/src/features/home/components/subjects/SubjectsView.tsx
@@ -6,6 +6,7 @@ import { useFilterOptions } from '@/features/home/hooks/useFilterOptions';
 import { useResolvedDefaultScope } from '@/features/home/hooks/useResolvedDefaultScope';
 import { useSubjects } from '@/features/home/hooks/useSubjects';
 import type { FilterOptions } from '@/features/home/types/filter';
+import { DEFAULT_PLAN_YEAR } from '@/features/home/constants/filter';
 
 function SubjectsView() {
   const { defaultScope, scopeError, scopeReady } = useResolvedDefaultScope();
@@ -25,6 +26,11 @@ function SubjectsView() {
   useEffect(() => {
     if (planOptions.length === 1 && filterState.applied.planId !== planOptions[0].id) {
       filterState.commitFilter('planId', planOptions[0].id);
+      return;
+    }
+    if (planOptions.length > 1 && !filterState.applied.planId) {
+      const defaultPlan = planOptions.find((p) => p.id.match(/\d+$/)?.[0] === String(DEFAULT_PLAN_YEAR));
+      if (defaultPlan) filterState.commitFilter('planId', defaultPlan.id);
     }
   }, [planOptions]);
 

--- a/src/features/home/constants/filter.ts
+++ b/src/features/home/constants/filter.ts
@@ -3,6 +3,8 @@ export const DEFAULT_UNIVERSITY_SHORT = 'UNICEN';
 export const DEFAULT_FACULTY_SHORT = 'EXACTAS';
 export const DEFAULT_CAREER_SHORT = 'Ing. en Sistemas';
 
+export const DEFAULT_PLAN_YEAR = 2024;
+
 export const INITIAL_FILTERS = {
   search: '',
   quadmester: 0,

--- a/src/features/upload/components/UploadSection.tsx
+++ b/src/features/upload/components/UploadSection.tsx
@@ -3,6 +3,7 @@ import SuccessModal from './SuccesModal';
 import UploadForm from './UploadForm';
 import { useEffect, useState } from 'react';
 import { getCareers, getSubjects, getCareerPlans } from '@/shared/services/api';
+import { DEFAULT_PLAN_YEAR } from '@/features/home/constants/filter';
 import type { Subject } from '@/features/home/types/subjects';
 import { AuthProvider } from '@/features/auth/context/AuthContext';
 import { AuthGuard } from '@/features/auth/components/AuthGuard';
@@ -91,7 +92,14 @@ function UploadSectionInner() {
     getCareerPlans(formData.careerId).then(({ data }) => {
       const mapped = data.map((p) => ({ value: p.id, label: p.name }));
       setPlans(mapped);
-      if (mapped.length === 1 && !formData.planId) onPlanChange(mapped[0].value);
+      if (!formData.planId) {
+        if (mapped.length === 1) {
+          onPlanChange(mapped[0].value);
+        } else if (mapped.length > 1) {
+          const defaultPlan = data.find((p) => p.year === DEFAULT_PLAN_YEAR);
+          if (defaultPlan) onPlanChange(defaultPlan.id);
+        }
+      }
     });
     getSubjects({ careerId: formData.careerId }).then(({ data }) => {
       setAllSubjects(data);


### PR DESCRIPTION
## Summary
- Agrega constante `DEFAULT_PLAN_YEAR = 2024` en `filter.ts`
- Home (SubjectsView): cuando hay múltiples planes y ninguno seleccionado, auto-selecciona el que coincide con el año 2024
- Upload (UploadSection): mismo comportamiento al cargar planes por carrera

## Test plan
- [ ] Cargar home → verificar que Plan 2024 queda seleccionado por defecto
- [ ] Cambiar carrera manualmente → volver a Ing. en Sistemas → Plan 2024 se re-selecciona
- [ ] Acceder con `?plan=...` en URL → el plan de URL tiene prioridad (no se sobreescribe)
- [ ] Upload: seleccionar Ing. en Sistemas → Plan 2024 pre-seleccionado

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic plan selection that defaults to the 2024 plan when multiple plan options are available but none is currently selected. This streamlines the user experience by pre-selecting a sensible default plan option, reducing manual selection requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->