### PR TITLE
feat(upload): move Google login button inside upload form

### DIFF
--- a/src/features/auth/components/GoogleLoginButton.tsx
+++ b/src/features/auth/components/GoogleLoginButton.tsx
@@ -3,12 +3,13 @@ import { Button } from '@/shared/components/ui/button';
 
 const GOOGLE_AUTH_URL = `${import.meta.env.PUBLIC_API_URL ?? 'http://localhost:3000'}/api/v1/auth/google`;
 
-export function GoogleLoginButton() {
+export function GoogleLoginButton({ onBeforeRedirect }: { onBeforeRedirect?: () => void } = {}) {
   return (
     <Button
       type='button'
       className='w-full gap-3 bg-primary text-black font-bold rounded-full py-3 h-auto cursor-pointer transition-all duration-200 hover:scale-[1.02] active:scale-95 hover:bg-primary'
       onClick={() => {
+        onBeforeRedirect?.();
         window.location.href = GOOGLE_AUTH_URL;
       }}
     >

--- a/src/features/upload/components/UploadForm.tsx
+++ b/src/features/upload/components/UploadForm.tsx
@@ -230,7 +230,10 @@ const UploadForm: React.FC<UploadFormProps> = ({
         ) : !isAuthenticated ? (
           <div className='flex flex-col items-center gap-3'>
             <p className='text-sm text-zinc-400'>Iniciá sesión para enviar el recurso</p>
-            <GoogleLoginButton />
+            <GoogleLoginButton onBeforeRedirect={() => {
+              const { file, imageFiles, ...draft } = formData;
+              localStorage.setItem('exactamente_upload_draft', JSON.stringify(draft));
+            }} />
           </div>
         ) : (
           <>

--- a/src/features/upload/components/UploadForm.tsx
+++ b/src/features/upload/components/UploadForm.tsx
@@ -7,6 +7,7 @@ import FileInput from './FileInput';
 import RadioGroupInput from './RadioGroupInput';
 import SelectInput from './SelectInput';
 import SubmitButton from './SubmitButton';
+import { GoogleLoginButton } from '@/features/auth/components/GoogleLoginButton';
 import type { UploadFormProps } from '../types/form';
 
 const YEARS = Array.from({ length: 2026 - 2000 + 1 }, (_, i) => {
@@ -75,6 +76,8 @@ const UploadForm: React.FC<UploadFormProps> = ({
   onFileModeChange,
   onDuplicateConfirm,
   onSubmit,
+  isAuthenticated,
+  isAuthLoading,
 }) => (
   <div className='bg-gradient-to-br from-zinc-900/90 to-zinc-950/95 rounded-xl shadow-sm border gradient-border p-6'>
     <form onSubmit={onSubmit} className='space-y-8'>
@@ -220,26 +223,39 @@ const UploadForm: React.FC<UploadFormProps> = ({
       </FormField>
 
       <div className='pt-6'>
-        {duplicateWarning?.hasSimilar && (
-          <div className='mb-4 rounded-xl border border-yellow-500/40 bg-yellow-500/10 px-4 py-3 text-yellow-200'>
-            <p className='text-sm font-semibold mb-2'>Ya existe un recurso similar en revisión o publicado. ¿Querés subirlo de todas formas?</p>
-            <button
-              type='button'
-              onClick={onDuplicateConfirm}
-              className='text-sm font-bold underline hover:text-yellow-100'
-            >
-              Subir de todas formas
-            </button>
+        {isAuthLoading ? (
+          <div className='flex justify-center py-3'>
+            <div className='w-6 h-6 border-2 border-primary/30 border-t-white rounded-full animate-spin' />
           </div>
+        ) : !isAuthenticated ? (
+          <div className='flex flex-col items-center gap-3'>
+            <p className='text-sm text-zinc-400'>Iniciá sesión para enviar el recurso</p>
+            <GoogleLoginButton />
+          </div>
+        ) : (
+          <>
+            {duplicateWarning?.hasSimilar && (
+              <div className='mb-4 rounded-xl border border-yellow-500/40 bg-yellow-500/10 px-4 py-3 text-yellow-200'>
+                <p className='text-sm font-semibold mb-2'>Ya existe un recurso similar en revisión o publicado. ¿Querés subirlo de todas formas?</p>
+                <button
+                  type='button'
+                  onClick={onDuplicateConfirm}
+                  className='text-sm font-bold underline hover:text-yellow-100'
+                >
+                  Subir de todas formas
+                </button>
+              </div>
+            )}
+            <ErrorMessage message={uploadError} />
+            <SubmitButton
+              uploadError={uploadError}
+              errors={errors}
+              isSubmitting={uploading}
+              text='Enviar Recurso'
+              submittingText='Subiendo...'
+            />
+          </>
         )}
-        <ErrorMessage message={uploadError} />
-        <SubmitButton
-          uploadError={uploadError}
-          errors={errors}
-          isSubmitting={uploading}
-          text='Enviar Recurso'
-          submittingText='Subiendo...'
-        />
       </div>
     </form>
   </div>

--- a/src/features/upload/components/UploadSection.tsx
+++ b/src/features/upload/components/UploadSection.tsx
@@ -16,6 +16,13 @@ const tiposRecurso = [
 
 function parseInitialValues() {
   if (typeof window === 'undefined') return {};
+
+  const draftRaw = localStorage.getItem('exactamente_upload_draft');
+  if (draftRaw) {
+    localStorage.removeItem('exactamente_upload_draft');
+    try { return JSON.parse(draftRaw); } catch {}
+  }
+
   const params = new URLSearchParams(window.location.search);
   const careerId = params.get('careerId');
   const planId = params.get('planId');

--- a/src/features/upload/components/UploadSection.tsx
+++ b/src/features/upload/components/UploadSection.tsx
@@ -6,23 +6,13 @@ import { getCareers, getSubjects, getCareerPlans } from '@/shared/services/api';
 import { DEFAULT_PLAN_YEAR } from '@/features/home/constants/filter';
 import type { Subject } from '@/features/home/types/subjects';
 import { AuthProvider } from '@/features/auth/context/AuthContext';
-import { AuthGuard } from '@/features/auth/components/AuthGuard';
-import { GoogleLoginButton } from '@/features/auth/components/GoogleLoginButton';
+import { useAuth } from '@/features/auth/hooks/useAuth';
 
 const tiposRecurso = [
   { value: 'resumen', label: 'Resumen' },
   { value: 'parcial', label: 'Parcial' },
   { value: 'final', label: 'Final' },
 ];
-
-function LoginGate() {
-  return (
-    <div className='max-w-md mx-auto pt-12 text-center space-y-4'>
-      <p className='text-zinc-400'>Iniciá sesión para subir recursos</p>
-      <GoogleLoginButton />
-    </div>
-  );
-}
 
 function parseInitialValues() {
   if (typeof window === 'undefined') return {};
@@ -40,6 +30,7 @@ function parseInitialValues() {
 }
 
 function UploadSectionInner() {
+  const { token, loading: authLoading } = useAuth();
   const {
     formData,
     errors,
@@ -120,37 +111,37 @@ function UploadSectionInner() {
   return (
     <>
       <SuccessModal showSuccess={showSuccess} closeSuccess={closeSuccess} />
-      <AuthGuard fallback={<LoginGate />}>
-        <div className='max-w-4xl mx-auto pt-12'>
-          <UploadForm
-            formData={formData}
-            errors={errors}
-            careers={careers}
-            plans={plans}
-            subjects={subjects}
-            tiposRecurso={tiposRecurso}
-            uploading={uploading}
-            uploadError={uploadError}
-            duplicateWarning={duplicateWarning}
-            onCareerChange={onCareerChange}
-            onPlanChange={onPlanChange}
-            onSubjectChange={onSubjectChange}
-            onTypeChange={onTypeChange}
-            onTitleChange={onTitleChange}
-            onSubtypeChange={onSubtypeChange}
-            onExamYearChange={onExamYearChange}
-            onExamMonthChange={onExamMonthChange}
-            onExamDayChange={onExamDayChange}
-            onTopicChange={onTopicChange}
-            onNotesChange={onNotesChange}
-            onFileChange={onFileChange}
-            onImagesChange={onImagesChange}
-            onFileModeChange={onFileModeChange}
-            onDuplicateConfirm={onDuplicateConfirm}
-            onSubmit={handleSubmit}
-          />
-        </div>
-      </AuthGuard>
+      <div className='max-w-4xl mx-auto pt-12'>
+        <UploadForm
+          formData={formData}
+          errors={errors}
+          careers={careers}
+          plans={plans}
+          subjects={subjects}
+          tiposRecurso={tiposRecurso}
+          uploading={uploading}
+          uploadError={uploadError}
+          duplicateWarning={duplicateWarning}
+          onCareerChange={onCareerChange}
+          onPlanChange={onPlanChange}
+          onSubjectChange={onSubjectChange}
+          onTypeChange={onTypeChange}
+          onTitleChange={onTitleChange}
+          onSubtypeChange={onSubtypeChange}
+          onExamYearChange={onExamYearChange}
+          onExamMonthChange={onExamMonthChange}
+          onExamDayChange={onExamDayChange}
+          onTopicChange={onTopicChange}
+          onNotesChange={onNotesChange}
+          onFileChange={onFileChange}
+          onImagesChange={onImagesChange}
+          onFileModeChange={onFileModeChange}
+          onDuplicateConfirm={onDuplicateConfirm}
+          onSubmit={handleSubmit}
+          isAuthenticated={!!token}
+          isAuthLoading={authLoading}
+        />
+      </div>
     </>
   );
 }

--- a/src/features/upload/hooks/useUploadForm.ts
+++ b/src/features/upload/hooks/useUploadForm.ts
@@ -64,7 +64,7 @@ async function imagesToPdf(imageFiles: File[]): Promise<File> {
   return new File([blob], 'imagenes.pdf', { type: 'application/pdf' });
 }
 
-type InitialValues = Partial<Pick<UploadFormState, 'careerId' | 'planId' | 'subjectId' | 'type'>>;
+type InitialValues = Partial<Omit<UploadFormState, 'file' | 'imageFiles'>>;
 
 type DuplicateWarning = { hasSimilar: boolean; similar: Array<{ id: string; title: string; status: string }> };
 

--- a/src/features/upload/types/form.ts
+++ b/src/features/upload/types/form.ts
@@ -54,4 +54,6 @@ export interface UploadFormProps {
   onFileModeChange: (mode: 'pdf' | 'images') => void;
   onDuplicateConfirm: () => void;
   onSubmit: (e: React.FormEvent) => void;
+  isAuthenticated: boolean;
+  isAuthLoading: boolean;
 }


### PR DESCRIPTION
## Summary
- The separate login gate (Google button replacing the form) is removed
- The form is always visible; the submit area is auth-aware: shows a spinner while loading, the Google login button when unauthenticated, and the normal submit button when authenticated
- Duplicate warning and error message remain inside the authenticated branch

## Test plan
- [ ] Go to `/upload` without being logged in → full form visible with Google login button at the bottom
- [ ] Log in → Google button replaced by "Enviar Recurso"
- [ ] `pnpm build` passes without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upload form is authentication-aware: shows a login prompt with Google sign-in and a loading spinner while auth is checked, then the upload UI when signed in.
  * Unauthenticated users can start an upload; a draft (excluding files/images) is saved locally.
  * Form preserves duplicate warnings, error display, and submit flow when authenticated.
  * Upload form can be prefilled with additional non-file fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->