### PR TITLE
feat(upload): block file input until user is authenticated

### DIFF
--- a/src/features/upload/components/UploadForm.tsx
+++ b/src/features/upload/components/UploadForm.tsx
@@ -211,55 +211,55 @@ const UploadForm: React.FC<UploadFormProps> = ({
       </FormField>
 
       <FormField label='Archivo' required>
-        <FileInput
-          fileMode={formData.fileMode}
-          onFileModeChange={onFileModeChange}
-          file={formData.file}
-          onFileChange={onFileChange}
-          imageFiles={formData.imageFiles}
-          onImagesChange={onImagesChange}
-          error={errors.file}
-        />
-      </FormField>
-
-      <div className='pt-6'>
         {isAuthLoading ? (
-          <div className='flex justify-center py-3'>
+          <div className='flex justify-center py-6'>
             <div className='w-6 h-6 border-2 border-primary/30 border-t-white rounded-full animate-spin' />
           </div>
         ) : !isAuthenticated ? (
-          <div className='flex flex-col items-center gap-3'>
-            <p className='text-sm text-zinc-400'>Iniciá sesión para enviar el recurso</p>
+          <div className='rounded-lg border border-dashed border-zinc-700 bg-zinc-900/50 p-6 flex flex-col items-center gap-3 text-center'>
+            <p className='text-sm text-zinc-400'>Iniciá sesión para poder adjuntar un archivo</p>
             <GoogleLoginButton onBeforeRedirect={() => {
               const { file, imageFiles, ...draft } = formData;
               localStorage.setItem('exactamente_upload_draft', JSON.stringify(draft));
             }} />
           </div>
         ) : (
-          <>
-            {duplicateWarning?.hasSimilar && (
-              <div className='mb-4 rounded-xl border border-yellow-500/40 bg-yellow-500/10 px-4 py-3 text-yellow-200'>
-                <p className='text-sm font-semibold mb-2'>Ya existe un recurso similar en revisión o publicado. ¿Querés subirlo de todas formas?</p>
-                <button
-                  type='button'
-                  onClick={onDuplicateConfirm}
-                  className='text-sm font-bold underline hover:text-yellow-100'
-                >
-                  Subir de todas formas
-                </button>
-              </div>
-            )}
-            <ErrorMessage message={uploadError} />
-            <SubmitButton
-              uploadError={uploadError}
-              errors={errors}
-              isSubmitting={uploading}
-              text='Enviar Recurso'
-              submittingText='Subiendo...'
-            />
-          </>
+          <FileInput
+            fileMode={formData.fileMode}
+            onFileModeChange={onFileModeChange}
+            file={formData.file}
+            onFileChange={onFileChange}
+            imageFiles={formData.imageFiles}
+            onImagesChange={onImagesChange}
+            error={errors.file}
+          />
         )}
-      </div>
+      </FormField>
+
+      {isAuthenticated && (
+        <div className='pt-6'>
+          {duplicateWarning?.hasSimilar && (
+            <div className='mb-4 rounded-xl border border-yellow-500/40 bg-yellow-500/10 px-4 py-3 text-yellow-200'>
+              <p className='text-sm font-semibold mb-2'>Ya existe un recurso similar en revisión o publicado. ¿Querés subirlo de todas formas?</p>
+              <button
+                type='button'
+                onClick={onDuplicateConfirm}
+                className='text-sm font-bold underline hover:text-yellow-100'
+              >
+                Subir de todas formas
+              </button>
+            </div>
+          )}
+          <ErrorMessage message={uploadError} />
+          <SubmitButton
+            uploadError={uploadError}
+            errors={errors}
+            isSubmitting={uploading}
+            text='Enviar Recurso'
+            submittingText='Subiendo...'
+          />
+        </div>
+      )}
     </form>
   </div>
 );


### PR DESCRIPTION
## Summary
- El campo de archivo ahora muestra un prompt de login cuando el usuario no está autenticado, en lugar del FileInput
- El botón de Google login se movió al área del archivo (donde está el bloqueo)
- Se eliminó la sección de login del pie del formulario — el botón de submit solo aparece si estás logueado

## Por qué
El archivo no se puede serializar en localStorage. Si el usuario seleccionaba un archivo y luego hacía login, el archivo se perdía porque el redirect de OAuth limpia el estado. Ahora el archivo solo se puede adjuntar una vez que estás autenticado.

## Test plan
- [ ] Sin login: campos de carrera/plan/materia/tipo/fecha editables, el campo archivo muestra mensaje de login
- [ ] Click en "Continuar con Google" desde el área del archivo → guarda el draft en localStorage → redirige
- [ ] Después del login: el draft se restaura y el FileInput aparece normalmente
- [ ] Con login activo: flujo de upload completo funciona igual que antes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload form draft is now preserved when redirecting to Google login.

* **Bug Fixes**
  * Improved file upload authentication flow with clearer sign-in prompts within the file field.
  * Loading state now displays directly in the file field during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->