### PR TITLE
feat(upload): disable file input instead of replacing it when unauthenticated

### DIFF
--- a/src/features/upload/components/FileInput.tsx
+++ b/src/features/upload/components/FileInput.tsx
@@ -10,6 +10,7 @@ interface FileInputProps {
   imageFiles: File[];
   onImagesChange: (files: File[]) => void;
   error?: string;
+  disabled?: boolean;
 }
 
 const MAX_SIZE = 20 * 1024 * 1024;
@@ -23,6 +24,7 @@ const FileInput: React.FC<FileInputProps> = ({
   imageFiles,
   onImagesChange,
   error,
+  disabled = false,
 }) => {
   const [thumbUrls, setThumbUrls] = useState<string[]>([]);
   const imgInputRef = useRef<HTMLInputElement>(null);
@@ -62,7 +64,7 @@ const FileInput: React.FC<FileInputProps> = ({
   };
 
   return (
-    <div className='space-y-3'>
+    <div className={`space-y-3 ${disabled ? 'opacity-40 pointer-events-none select-none' : ''}`}>
       {/* Mode toggle */}
       <div className='flex rounded-xl border border-primary/30 overflow-hidden w-fit'>
         {(['pdf', 'images'] as const).map((mode) => (

--- a/src/features/upload/components/UploadForm.tsx
+++ b/src/features/upload/components/UploadForm.tsx
@@ -211,55 +211,56 @@ const UploadForm: React.FC<UploadFormProps> = ({
       </FormField>
 
       <FormField label='Archivo' required>
+        <FileInput
+          fileMode={formData.fileMode}
+          onFileModeChange={onFileModeChange}
+          file={formData.file}
+          onFileChange={onFileChange}
+          imageFiles={formData.imageFiles}
+          onImagesChange={onImagesChange}
+          error={errors.file}
+          disabled={!isAuthenticated && !isAuthLoading}
+        />
+      </FormField>
+
+      <div className='pt-6'>
         {isAuthLoading ? (
-          <div className='flex justify-center py-6'>
+          <div className='flex justify-center py-3'>
             <div className='w-6 h-6 border-2 border-primary/30 border-t-white rounded-full animate-spin' />
           </div>
         ) : !isAuthenticated ? (
-          <div className='rounded-lg border border-dashed border-zinc-700 bg-zinc-900/50 p-6 flex flex-col items-center gap-3 text-center'>
-            <p className='text-sm text-zinc-400'>Iniciá sesión para poder adjuntar un archivo</p>
+          <div className='flex flex-col items-center gap-3'>
+            <p className='text-sm text-zinc-400'>Iniciá sesión para enviar el recurso</p>
             <GoogleLoginButton onBeforeRedirect={() => {
               const { file, imageFiles, ...draft } = formData;
               localStorage.setItem('exactamente_upload_draft', JSON.stringify(draft));
             }} />
           </div>
         ) : (
-          <FileInput
-            fileMode={formData.fileMode}
-            onFileModeChange={onFileModeChange}
-            file={formData.file}
-            onFileChange={onFileChange}
-            imageFiles={formData.imageFiles}
-            onImagesChange={onImagesChange}
-            error={errors.file}
-          />
+          <>
+            {duplicateWarning?.hasSimilar && (
+              <div className='mb-4 rounded-xl border border-yellow-500/40 bg-yellow-500/10 px-4 py-3 text-yellow-200'>
+                <p className='text-sm font-semibold mb-2'>Ya existe un recurso similar en revisión o publicado. ¿Querés subirlo de todas formas?</p>
+                <button
+                  type='button'
+                  onClick={onDuplicateConfirm}
+                  className='text-sm font-bold underline hover:text-yellow-100'
+                >
+                  Subir de todas formas
+                </button>
+              </div>
+            )}
+            <ErrorMessage message={uploadError} />
+            <SubmitButton
+              uploadError={uploadError}
+              errors={errors}
+              isSubmitting={uploading}
+              text='Enviar Recurso'
+              submittingText='Subiendo...'
+            />
+          </>
         )}
-      </FormField>
-
-      {isAuthenticated && (
-        <div className='pt-6'>
-          {duplicateWarning?.hasSimilar && (
-            <div className='mb-4 rounded-xl border border-yellow-500/40 bg-yellow-500/10 px-4 py-3 text-yellow-200'>
-              <p className='text-sm font-semibold mb-2'>Ya existe un recurso similar en revisión o publicado. ¿Querés subirlo de todas formas?</p>
-              <button
-                type='button'
-                onClick={onDuplicateConfirm}
-                className='text-sm font-bold underline hover:text-yellow-100'
-              >
-                Subir de todas formas
-              </button>
-            </div>
-          )}
-          <ErrorMessage message={uploadError} />
-          <SubmitButton
-            uploadError={uploadError}
-            errors={errors}
-            isSubmitting={uploading}
-            text='Enviar Recurso'
-            submittingText='Subiendo...'
-          />
-        </div>
-      )}
+      </div>
     </form>
   </div>
 );


### PR DESCRIPTION
## Summary
- Revierte el approach del PR #75 (que reemplazaba el FileInput con un prompt de login)
- Agrega prop `disabled` a `FileInput` que pone el componente en gris con `pointer-events-none`
- `UploadForm` pasa `disabled={!isAuthenticated && !isAuthLoading}` al `FileInput`
- La estructura del formulario queda igual que antes — el login button sigue abajo

## Por qué
El archivo no se puede serializar en localStorage, así que si el usuario lo seleccionaba antes de loguearse se perdía al volver del OAuth redirect. El disabled visual hace que sea obvio que necesitás loguearte primero, sin cambiar la estructura del form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * File input field now displays as disabled when not logged in, providing clearer visual feedback that authentication is required.
  * Upload form UI reorganized for improved clarity during authentication states and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->