### PR TITLE
fix(resource): mostrar carrera real en header de recursos

### DIFF
--- a/src/features/resource/components/HeaderResources.tsx
+++ b/src/features/resource/components/HeaderResources.tsx
@@ -5,6 +5,7 @@ interface Props {
   urlImg: string;
   title: string;
   subject: string;
+  career: string;
   cantResource: number;
   children?: React.ReactNode;
   loading: boolean;
@@ -14,6 +15,7 @@ const HeaderResources: React.FC<Props> = ({
   urlImg,
   title,
   subject,
+  career,
   cantResource,
   loading,
   children,
@@ -25,7 +27,7 @@ const HeaderResources: React.FC<Props> = ({
         <h2 className='text-3xl sm:text-4xl font-bold text-foreground'>{title}</h2>
       </div>
       <h5 className='text-foreground-secondary text-xl mt-2 font-semibold'>{subject}</h5>
-      <p className='text-foreground-muted mt-1'>Ingeniería en Sistemas</p>
+      {career && <p className='text-foreground-muted mt-1'>{career}</p>}
       {loading ? (
         <p className='w-max  mt-3 text-transparent font-semibold rounded-full px-4 py-2 bg-yellow-500/10 border border-yellow-500/30 animate-pulse'>
           22 recursos disponibles

--- a/src/features/resource/components/ResourcesView.tsx
+++ b/src/features/resource/components/ResourcesView.tsx
@@ -16,6 +16,7 @@ function ResourcesView({ subject, type }: Props) {
       <HeaderResources
         loading={loading}
         subject={subject.title}
+        career={subject.careers[0]?.careerName ?? ''}
         cantResource={data ? data.length : 0}
         title={type}
         urlImg='/images/materia-2.webp'


### PR DESCRIPTION
## Summary
- Reemplaza el string hardcodeado "Ingeniería en Sistemas" en `HeaderResources` por el `careerName` real de la materia.
- `ResourcesView` pasa `subject.careers[0]?.careerName ?? ''` como prop `career`; si no hay carrera, el `<p>` no se renderiza.

Closes #82

## Test plan
- [ ] `/[id]/resumenes`, `/[id]/parciales`, `/[id]/finales` muestran la carrera correcta de la materia.
- [ ] Materias de carreras distintas a Sistemas ya no muestran "Ingeniería en Sistemas".
- [ ] `pnpm build` pasa sin errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Career information displayed in resource headers now dynamically reflects subject data instead of displaying a fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->