### PR TITLE
fix(home): preservar filtros al volver desde recursos (#56)

### DIFF
--- a/src/features/home/components/subjects/CardSubject.tsx
+++ b/src/features/home/components/subjects/CardSubject.tsx
@@ -16,6 +16,7 @@ type Props = {
   careers: SubjectCareer[];
   activeCareerId: string;
   resourceCounts: ResourceCounts;
+  homeQuery: string;
 };
 
 type ResourceButtonProps = {
@@ -68,7 +69,7 @@ function abbreviateUniversity (name: string): string {
   return initials || name;
 }
 
-function Card ({ id, title, shortName, url, quadmester, year, careers, activeCareerId, resourceCounts }: Props) {
+function Card ({ id, title, shortName, url, quadmester, year, careers, activeCareerId, resourceCounts, homeQuery }: Props) {
   const primaryCareer = careers.find((c) => c.careerId === activeCareerId) ?? careers[0];
   const displayYear = primaryCareer?.year ?? year;
   const displayQuadmester = primaryCareer?.quadmester ?? quadmester;
@@ -78,6 +79,7 @@ function Card ({ id, title, shortName, url, quadmester, year, careers, activeCar
   const careerLabel = primaryCareer?.careerName;
   const planId = primaryCareer?.planId ?? '';
   const uploadBase = `/upload?careerId=${activeCareerId}&planId=${planId}&subjectId=${id}`;
+  const resourceSuffix = homeQuery ? `?home=${encodeURIComponent(homeQuery)}` : '';
   return (
     <article className='group rounded-xl bg-gradient-to-br from-zinc-900/50 to-zinc-950/95 border gradient-border  overflow-hidden hover:border-zinc-700/80 transition-all duration-300 hover:shadow-2xl hover:shadow-black/20 flex flex-col '>
       {/* Header */}
@@ -120,7 +122,7 @@ function Card ({ id, title, shortName, url, quadmester, year, careers, activeCar
 
           <div className='flex flex-col space-y-3 w-full'>
             <ResourceButton
-              resourceUrl={`./${id}/resumenes`}
+              resourceUrl={`./${id}/resumenes${resourceSuffix}`}
               uploadUrl={`${uploadBase}&type=resumen`}
               count={resourceCounts.resumen}
               label='Resumenes'
@@ -129,7 +131,7 @@ function Card ({ id, title, shortName, url, quadmester, year, careers, activeCar
               activeIconClass='fill-emerald-200'
             />
             <ResourceButton
-              resourceUrl={`./${id}/parciales`}
+              resourceUrl={`./${id}/parciales${resourceSuffix}`}
               uploadUrl={`${uploadBase}&type=parcial`}
               count={resourceCounts.parcial}
               label='Parciales'
@@ -138,7 +140,7 @@ function Card ({ id, title, shortName, url, quadmester, year, careers, activeCar
               activeIconClass='fill-blue-200'
             />
             <ResourceButton
-              resourceUrl={`./${id}/finales`}
+              resourceUrl={`./${id}/finales${resourceSuffix}`}
               uploadUrl={`${uploadBase}&type=final`}
               count={resourceCounts.final}
               label='Finales'

--- a/src/features/home/components/subjects/ListOfSubjects.tsx
+++ b/src/features/home/components/subjects/ListOfSubjects.tsx
@@ -2,7 +2,7 @@ import type { PropsListOfSubjects } from '../../types/filter';
 import Card from './CardSubject';
 import CardSubjectLoading from './CardSubjectLoading';
 
-function ListOfSubjects ({ subjects, onClearAll, loading, hasMore, showMore, activeCareerId }: PropsListOfSubjects) {
+function ListOfSubjects ({ subjects, onClearAll, loading, hasMore, showMore, activeCareerId, homeQuery }: PropsListOfSubjects) {
   if (loading) {
     return (
       <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 lg:gap-8'>
@@ -37,6 +37,7 @@ function ListOfSubjects ({ subjects, onClearAll, loading, hasMore, showMore, act
               key={subject.id}
               {...subject}
               activeCareerId={activeCareerId}
+              homeQuery={homeQuery}
             />
           ))
         )}

--- a/src/features/home/components/subjects/SubjectsView.tsx
+++ b/src/features/home/components/subjects/SubjectsView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import FilterBar from './FilterBar';
 import ListOfSubjects from './ListOfSubjects';
-import { useFilterState } from '@/features/home/hooks/useFilterState';
+import { useFilterState, buildFilterSearchParams } from '@/features/home/hooks/useFilterState';
 import { useFilterOptions } from '@/features/home/hooks/useFilterOptions';
 import { useResolvedDefaultScope } from '@/features/home/hooks/useResolvedDefaultScope';
 import { useSubjects } from '@/features/home/hooks/useSubjects';
@@ -33,6 +33,8 @@ function SubjectsView() {
       if (defaultPlan) filterState.commitFilter('planId', defaultPlan.id);
     }
   }, [planOptions]);
+
+  const homeQuery = useMemo(() => buildFilterSearchParams(filterState.applied).toString(), [filterState.applied]);
 
   const options = useMemo<FilterOptions>(
     () => ({
@@ -66,6 +68,7 @@ function SubjectsView() {
         showMore={showMore}
         loading={loading}
         activeCareerId={filterState.applied.careerId}
+        homeQuery={homeQuery}
       />
     </>
   );

--- a/src/features/home/hooks/useFilterState.ts
+++ b/src/features/home/hooks/useFilterState.ts
@@ -33,6 +33,18 @@ function applyCascade<K extends keyof DraftFilters>(
   return next;
 }
 
+export function buildFilterSearchParams(applied: AppliedFilters): URLSearchParams {
+  const params = new URLSearchParams();
+  if (applied.search) params.set('q', applied.search);
+  if (applied.universityId) params.set('university', applied.universityId);
+  if (applied.facultyId) params.set('faculty', applied.facultyId);
+  if (applied.careerId) params.set('career', applied.careerId);
+  if (applied.planId) params.set('plan', applied.planId);
+  if (applied.year) params.set('year', String(applied.year));
+  if (applied.quadmester) params.set('quadmester', String(applied.quadmester));
+  return params;
+}
+
 function readInitialFilters(defaultScope: ResolvedDefaultScope | null): {
   applied: AppliedFilters;
   urlHadUniversity: boolean;
@@ -104,15 +116,7 @@ export const useFilterState = (defaultScope: ResolvedDefaultScope | null) => {
   // Sync URL when applied changes (debounced so rapid search keystrokes don't spam replaceState)
   useEffect(() => {
     const timer = setTimeout(() => {
-      const params = new URLSearchParams();
-      if (applied.search) params.set('q', applied.search);
-      if (applied.universityId) params.set('university', applied.universityId);
-      if (applied.facultyId) params.set('faculty', applied.facultyId);
-      if (applied.careerId) params.set('career', applied.careerId);
-      if (applied.planId) params.set('plan', applied.planId);
-      if (applied.year) params.set('year', String(applied.year));
-      if (applied.quadmester) params.set('quadmester', String(applied.quadmester));
-      const qs = params.toString();
+      const qs = buildFilterSearchParams(applied).toString();
       history.replaceState(null, '', qs ? `?${qs}` : window.location.pathname);
     }, 300);
     return () => clearTimeout(timer);

--- a/src/features/home/types/filter.ts
+++ b/src/features/home/types/filter.ts
@@ -50,4 +50,5 @@ export type PropsListOfSubjects = {
   hasMore: boolean;
   showMore: () => void;
   activeCareerId: string;
+  homeQuery: string;
 };

--- a/src/pages/[id]/finales.astro
+++ b/src/pages/[id]/finales.astro
@@ -18,13 +18,17 @@ const subject = await getSubjectById(id as string);
 if (!subject) {
   return Astro.redirect('/');
 }
+
+const homeQuery = Astro.url.searchParams.get('home') ?? '';
+const homeHref = homeQuery ? `../?${homeQuery}#subjects` : `../#subjects`;
+const tabSuffix = homeQuery ? `?home=${encodeURIComponent(homeQuery)}` : '';
 ---
 
 <Layout>
   <ContainerSection id='finales'>
-    <Breadcrumb url={`../#subjects`} title={subject.title}>
+    <Breadcrumb url={homeHref} title={subject.title}>
       <ContainerLink
-        url={`./resumenes`}
+        url={`./resumenes${tabSuffix}`}
         class='group/resource hover:scale-105 justify-between active:scale-95 grayscale-50 bg-gradient-to-br from-emerald-500/50 to-emerald-600/10 border border-emerald-500/40 hover:border-emerald-400/60 text-emerald-200 hover:text-emerald-100 font-semibold flex items-center gap-3 transition-all duration-200'
       >
         <div class='flex items-center gap-2'>
@@ -34,7 +38,7 @@ if (!subject) {
       </ContainerLink>
 
       <ContainerLink
-        url={`./parciales`}
+        url={`./parciales${tabSuffix}`}
         class='group/resource hover:scale-105 justify-between active:scale-95 grayscale-50 bg-gradient-to-br from-blue-500/50 to-blue-600/10 border-2 border-blue-500/40 hover:border-blue-400/60 text-blue-200 hover:text-blue-100 font-semibold flex items-center gap-3 transition-all duration-200'
       >
         <div class='flex items-center gap-2'>
@@ -44,7 +48,7 @@ if (!subject) {
       </ContainerLink>
 
       <ContainerLink
-        url={`./finales`}
+        url={`./finales${tabSuffix}`}
         class='pointer-events-none cursor-not-allowed group/resource hover:scale-105 justify-between active:scale-95 grayscale-100 bg-gradient-to-br from-purple-500/50 to-purple-600/10 border-2 border-purple-500/40 hover:border-purple-400/60 text-purple-200 hover:text-purple-100 font-semibold flex items-center gap-3 transition-all duration-200'
       >
         <div class='flex items-center gap-2'>

--- a/src/pages/[id]/parciales.astro
+++ b/src/pages/[id]/parciales.astro
@@ -20,13 +20,17 @@ const subject = await getSubjectById(id as string);
 if (!subject) {
   return Astro.redirect('/');
 }
+
+const homeQuery = Astro.url.searchParams.get('home') ?? '';
+const homeHref = homeQuery ? `../?${homeQuery}#subjects` : `../#subjects`;
+const tabSuffix = homeQuery ? `?home=${encodeURIComponent(homeQuery)}` : '';
 ---
 
 <Layout>
   <ContainerSection id='parciales'>
-    <Breadcrumb url={`../#subjects`} title={subject.title}>
+    <Breadcrumb url={homeHref} title={subject.title}>
       <ContainerLink
-        url={`./resumenes`}
+        url={`./resumenes${tabSuffix}`}
         class='group/resource hover:scale-105 justify-between active:scale-95 grayscale-50 bg-gradient-to-br from-emerald-500/50 to-emerald-600/10 border border-emerald-500/40 hover:border-emerald-400/60 text-emerald-200 hover:text-emerald-100 font-semibold flex items-center gap-3 transition-all duration-200'
       >
         <div class='flex items-center gap-2'>
@@ -36,7 +40,7 @@ if (!subject) {
       </ContainerLink>
 
       <ContainerLink
-        url={`./parciales`}
+        url={`./parciales${tabSuffix}`}
         class='grayscale-100 pointer-events-none cursor-not-allowed group/resource hover:scale-105 justify-between active:scale-95 bg-gradient-to-br from-blue-500/50 to-blue-600/10 border-2 border-blue-500/40 hover:border-blue-400/60 text-blue-200 hover:text-blue-100 font-semibold flex items-center gap-3 transition-all duration-200'
       >
         <div class='flex items-center gap-2'>
@@ -46,7 +50,7 @@ if (!subject) {
       </ContainerLink>
 
       <ContainerLink
-        url={`./finales`}
+        url={`./finales${tabSuffix}`}
         class='group/resource hover:scale-105 justify-between active:scale-95 grayscale-50 bg-gradient-to-br from-purple-500/50 to-purple-600/10 border-2 border-purple-500/40 hover:border-purple-400/60 text-purple-200 hover:text-purple-100 font-semibold flex items-center gap-3 transition-all duration-200'
       >
         <div class='flex items-center gap-2'>

--- a/src/pages/[id]/resumenes.astro
+++ b/src/pages/[id]/resumenes.astro
@@ -21,13 +21,17 @@ const subject = await getSubjectById(id as string);
 if (!subject) {
   return Astro.redirect('/');
 }
+
+const homeQuery = Astro.url.searchParams.get('home') ?? '';
+const homeHref = homeQuery ? `../?${homeQuery}#subjects` : `../#subjects`;
+const tabSuffix = homeQuery ? `?home=${encodeURIComponent(homeQuery)}` : '';
 ---
 
 <Layout>
   <ContainerSection id='resumenes'>
-    <Breadcrumb url={`../#subjects`} title={subject.title}>
+    <Breadcrumb url={homeHref} title={subject.title}>
       <ContainerLink
-        url={`./resumenes`}
+        url={`./resumenes${tabSuffix}`}
         class='cursor-not-allowed pointer-events-none group/resource hover:scale-105 justify-between active:scale-95 grayscale-100 bg-gradient-to-br from-emerald-500/50 to-emerald-600/10 border border-emerald-500/40 hover:border-emerald-400/60 text-emerald-200 hover:text-emerald-100 font-semibold flex items-center gap-3 transition-all duration-200'
       >
         <div class='flex items-center gap-2'>
@@ -37,7 +41,7 @@ if (!subject) {
       </ContainerLink>
 
       <ContainerLink
-        url={`./parciales`}
+        url={`./parciales${tabSuffix}`}
         class='group/resource hover:scale-105 justify-between active:scale-95 grayscale-50 bg-gradient-to-br from-blue-500/50 to-blue-600/10 border-2 border-blue-500/40 hover:border-blue-400/60 text-blue-200 hover:text-blue-100 font-semibold flex items-center gap-3 transition-all duration-200'
       >
         <div class='flex items-center gap-2'>
@@ -47,7 +51,7 @@ if (!subject) {
       </ContainerLink>
 
       <ContainerLink
-        url={`./finales`}
+        url={`./finales${tabSuffix}`}
         class='group/resource hover:scale-105 justify-between active:scale-95 grayscale-50 bg-gradient-to-br from-purple-500/50 to-purple-600/10 border-2 border-purple-500/40 hover:border-purple-400/60 text-purple-200 hover:text-purple-100 font-semibold flex items-center gap-3 transition-all duration-200'
       >
         <div class='flex items-center gap-2'>


### PR DESCRIPTION
Closes #56

## Summary
- Paso la querystring de filtros del home como param `home` al navegar a una página de recursos.
- El breadcrumb "Volver al inicio" la usa para reconstruir la URL de home con los filtros activos.
- Los links entre tabs (Resumenes/Parciales/Finales) propagan el `home` para no perderlo al cambiar de tipo.
- Extraigo `buildFilterSearchParams` de `useFilterState` para reusarlo en el sync de URL y en `SubjectsView`.

## Test plan
- [x] En home, seleccionar un Plan (ej: 2024) → la URL refleja `?plan=...`
- [x] Entrar a una materia (Resumenes/Parciales/Finales) → la URL incluye `?home=plan%3D...`
- [x] Click "Volver al inicio" → vuelve a home con el plan seleccionado, sin reset
- [x] Cambiar de tab (Resumenes → Parciales) preserva el `home`
- [x] Entrar directo a una materia sin `home` → "Volver al inicio" lleva a `/#subjects` (comportamiento previo)
- [x] "Restablecer filtros" en home sigue limpiando todo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filter and search state from the home page is now preserved when navigating to resource views (summaries, midterms, finals), allowing you to maintain your search context as you explore different resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->