### PR TITLE
fix(ui): header z-index por encima de dropdowns (#58)

### DIFF
--- a/src/shared/components/Header.astro
+++ b/src/shared/components/Header.astro
@@ -3,7 +3,7 @@ import ContainerLink from './ContainerLink.astro';
 import UserMenu from '@/features/auth/components/UserMenu';
 ---
 
-<header class='fixed top-2 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-1.5rem)] max-w-6xl 2xl:max-w-8xl rounded-2xl bg-gradient-to-br from-zinc-900/80 to-zinc-950/80 backdrop-blur-md gradient-border-all shadow-2xl shadow-black/50' id='blur-element'>
+<header class='fixed top-2 left-1/2 -translate-x-1/2 z-[60] w-[calc(100%-1.5rem)] max-w-6xl 2xl:max-w-8xl rounded-2xl bg-gradient-to-br from-zinc-900/80 to-zinc-950/80 backdrop-blur-md gradient-border-all shadow-2xl shadow-black/50' id='blur-element'>
   <div class='relative w-full pl-3 sm:pl-4 pr-1 sm:pr-2'>
     <div class='flex h-16 items-center justify-between'>
       <div class='md:flex md:items-center md:gap-12'>

--- a/src/shared/components/ui/dialog.tsx
+++ b/src/shared/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[70] bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[70] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}


### PR DESCRIPTION
Closes #58

## Resumen
- Header sube a `z-[60]` para quedar siempre sobre los portales de Select/Popover (que renderizan con `z-50` en `body`).
- Dialog overlay y content suben a `z-[70]` para que los modales (ej: `SuccesModal`) sigan cubriendo el header.

## Causa
Header y dropdowns compartían `z-50`. Como los portales de Radix se montan en `<body>` (más tarde en el DOM), ganaban el orden de pintado y tapaban al header al hacer scroll.

## Test plan
- [ ] Home: abrir filtro de materias y hacer scroll → dropdown queda debajo del header.
- [ ] Upload: abrir los selects del form y hacer scroll → idem.
- [ ] Upload success: verificar que el modal de éxito sigue cubriendo el header.
- [ ] Mobile: menú hamburguesa abre/cierra correctamente y el overlay no se rompe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual layering of header and dialog components to ensure correct display order across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->