### PR TITLE
fix(ui): resaltar con fondo el item seleccionado en selects (#79)

### DIFF
--- a/src/features/upload/components/SelectInput.tsx
+++ b/src/features/upload/components/SelectInput.tsx
@@ -43,7 +43,7 @@ const SelectInput: React.FC<SelectInputProps> = ({
           <SelectItem
             key={option.value}
             value={option.value}
-            className='text-white font-bold focus:bg-zinc-700 focus:text-white cursor-pointer'
+            className='text-white font-bold cursor-pointer focus:bg-zinc-700/60 focus:text-white data-[state=checked]:bg-zinc-700 data-[state=checked]:focus:bg-zinc-600'
           >
             {option.label}
           </SelectItem>

--- a/src/shared/components/FilterCombobox.tsx
+++ b/src/shared/components/FilterCombobox.tsx
@@ -125,23 +125,31 @@ const FilterCombobox: React.FC<FilterComboboxProps> = ({
             )}
             {!isLoading && (
               <CommandGroup>
-                {options.map((option) => (
-                  <CommandItem
-                    key={option.id}
-                    value={option.label}
-                    onSelect={() => handleSelect(option.id)}
-                    className='text-zinc-200 cursor-pointer hover:bg-zinc-700 data-[selected=true]:bg-zinc-700 data-[selected=true]:text-zinc-100'
-                  >
-                    {option.label}
-                    <Check
+                {options.map((option) => {
+                  const isSelected = value === option.id;
+                  return (
+                    <CommandItem
+                      key={option.id}
+                      value={option.label}
+                      onSelect={() => handleSelect(option.id)}
                       className={cn(
-                        'ml-auto',
-                        value === option.id ? 'opacity-100 text-white' : 'opacity-0'
+                        'text-zinc-200 cursor-pointer',
+                        isSelected
+                          ? 'bg-zinc-700 text-white data-[selected=true]:bg-zinc-600 data-[selected=true]:text-white'
+                          : 'data-[selected=true]:bg-zinc-700/60 data-[selected=true]:text-zinc-100'
                       )}
-                      size={14}
-                    />
-                  </CommandItem>
-                ))}
+                    >
+                      {option.label}
+                      <Check
+                        className={cn(
+                          'ml-auto',
+                          isSelected ? 'opacity-100 text-white' : 'opacity-0'
+                        )}
+                        size={14}
+                      />
+                    </CommandItem>
+                  );
+                })}
               </CommandGroup>
             )}
           </CommandList>


### PR DESCRIPTION
## Resumen
Resuelve #79. El item seleccionado en los selects ahora tiene fondo destacado (`bg-zinc-700`), no solo el checkmark.

- **FilterCombobox** (Carrera/Plan en home, Carrera/Plan/Materia en upload): bg destacado sobre el item elegido; hover/focus sobre items no seleccionados usa `bg-zinc-700/60` para no confundirse con el estado activo.
- **SelectInput** (Año/Mes/Día/Tema/Subtipo en upload): `data-[state=checked]:bg-zinc-700` con focus mas suave (`bg-zinc-700/60`) para distinguir hover del item elegido.

## Test plan
- [ ] En home, abrir select de Carrera y verificar que el item seleccionado tiene fondo distinto al resto.
- [ ] Idem en select de Plan.
- [ ] En `/upload`, abrir Carrera/Plan/Materia y verificar el bg del seleccionado.
- [ ] En `/upload` con tipo "Parcial" o "Final", abrir Año, Mes, Día, Tema, Subtipo: verificar bg sobre el seleccionado.
- [ ] Hover sobre items no seleccionados se distingue del estado activo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced visual styling and focus states for form input selection components.
  * Improved appearance consistency when items are selected or hovered in dropdown and filter options.
  * Refined visual feedback to provide clearer indication of interactive states in form controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->