### PR TITLE
feat(home): sección de donaciones vía Cafecito (issue #74)

### DIFF
--- a/src/features/home/components/DonationsBanner.astro
+++ b/src/features/home/components/DonationsBanner.astro
@@ -1,0 +1,23 @@
+---
+import { CAFECITO_URL } from '@/features/home/constants/donations';
+---
+
+<section class="relative w-full py-4">
+  <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 rounded-xl bg-gradient-to-br from-zinc-900/50 to-zinc-950/95 border border-zinc-800 px-6 py-4">
+    <p class="text-sm text-zinc-400">
+      Exactamente tiene costos reales —
+      <span class="text-zinc-500">servidor, dominio, almacenamiento.</span>
+    </p>
+    <a
+      href={CAFECITO_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="shrink-0 inline-flex items-center gap-1.5 border border-zinc-700 rounded-lg px-4 py-2 text-sm font-semibold text-zinc-400 hover:text-zinc-200 hover:border-zinc-500 transition-colors duration-200"
+    >
+      Cafecito
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
+        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 17L17 7M7 7h10v10"/>
+      </svg>
+    </a>
+  </div>
+</section>

--- a/src/features/home/components/DonationsBanner.astro
+++ b/src/features/home/components/DonationsBanner.astro
@@ -2,22 +2,37 @@
 import { CAFECITO_URL } from '@/features/home/constants/donations';
 ---
 
-<section class="relative w-full py-4">
-  <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 rounded-xl bg-gradient-to-br from-zinc-900/50 to-zinc-950/95 border border-zinc-800 px-6 py-4">
-    <p class="text-sm text-zinc-400">
-      Exactamente tiene costos reales —
-      <span class="text-zinc-500">servidor, dominio, almacenamiento.</span>
-    </p>
+<section class="relative w-full py-16 md:py-20">
+  <h2 class="text-3xl sm:text-4xl font-bold mb-10 text-center text-foreground">
+    Apoyá el <span class="gradient-text">proyecto</span>
+  </h2>
+
+  <div class="relative flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6 rounded-xl bg-gradient-to-br from-zinc-900/50 to-zinc-950/95 border border-zinc-800 px-8 py-8 overflow-hidden hover:border-zinc-700 transition-all duration-300">
+    <div class="absolute top-0 right-0 w-48 h-48 bg-gradient-to-bl from-yellow-500/5 to-transparent rounded-full blur-3xl pointer-events-none" />
+
+    <div class="flex flex-col gap-2 max-w-xl">
+      <p class="text-base font-semibold text-foreground">
+        Exactamente tiene costos reales
+      </p>
+      <p class="text-sm text-foreground-muted">
+        Servidor, dominio, almacenamiento — todo sale de nuestro bolsillo. Si la plataforma te sirvió alguna vez, un cafecito ayuda a mantenerla viva.
+      </p>
+    </div>
+
     <a
       href={CAFECITO_URL}
       target="_blank"
       rel="noopener noreferrer"
-      class="shrink-0 inline-flex items-center gap-1.5 border border-zinc-700 rounded-lg px-4 py-2 text-sm font-semibold text-zinc-400 hover:text-zinc-200 hover:border-zinc-500 transition-colors duration-200"
+      class="shrink-0 inline-flex items-center gap-2 gradient-bg-animated p-[1px] rounded-lg"
     >
-      Cafecito
-      <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
-        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 17L17 7M7 7h10v10"/>
-      </svg>
+      <span class="inline-flex items-center gap-2 rounded-[calc(0.5rem-1px)] bg-zinc-950 px-5 py-2.5 text-sm font-semibold text-foreground hover:bg-zinc-900 transition-colors duration-200">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" class="shrink-0 text-yellow-400">
+          <path d="M18 8h1a4 4 0 0 1 0 8h-1" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+          <path d="M2 8h16v9a4 4 0 0 1-4 4H6a4 4 0 0 1-4-4V8z" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+          <path d="M6 1v3M10 1v3M14 1v3" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        Invitanos un cafecito
+      </span>
     </a>
   </div>
 </section>

--- a/src/features/home/constants/donations.ts
+++ b/src/features/home/constants/donations.ts
@@ -1,0 +1,1 @@
+export const CAFECITO_URL = 'https://cafecito.app/exactamente';

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,9 +2,11 @@
 import Layout from "@/layouts/Layout.astro";
 import SubjectsSection from "@/features/home/components/subjects/SubjectsSection.astro";
 import SponsorsSection from "@/features/home/components/sponsors/SponsorsSection.astro";
+import DonationsBanner from "@/features/home/components/DonationsBanner.astro";
 ---
 
 <Layout hideFooterSponsor={true}>
   <SubjectsSection />
+  <DonationsBanner />
   <SponsorsSection />
 </Layout>

--- a/src/shared/components/Footer.astro
+++ b/src/shared/components/Footer.astro
@@ -72,6 +72,7 @@ const { hideSponsor = false } = Astro.props;
         © Todos los derechos reservados 2025.
       </p>
       <div class='flex items-center gap-4'>
+        <a href='https://cafecito.app/exactamente' target='_blank' rel='noopener noreferrer' class='text-sm text-zinc-600 hover:text-zinc-400 transition-colors duration-200'>Apoyá el proyecto</a>
         <a href='/privacy' class='text-sm text-zinc-600 hover:text-zinc-400 transition-colors duration-200'>Privacidad</a>
         <a href='/terms' class='text-sm text-zinc-600 hover:text-zinc-400 transition-colors duration-200'>Términos</a>
         <span class='text-sm text-zinc-600'>Facultad de Ciencias Exactas</span>


### PR DESCRIPTION
## Resumen

- Nuevo componente `DonationsBanner.astro` en la home — franja horizontal compacta entre `SubjectsSection` y `SponsorsSection`
- Link "Apoyá el proyecto" en el strip inferior del footer
- Constante `CAFECITO_URL` en `src/features/home/constants/donations.ts`

Closes #74

## Plan de verificación

- [ ] Banner visible en la home entre las materias y los sponsors
- [ ] Link en footer aparece junto a Privacidad/Términos
- [ ] Botón "Cafecito" lleva a `cafecito.app/exactamente` en tab nuevo
- [ ] No interrumpe la experiencia de búsqueda principal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Invitanos un cafecito” donations banner on the home page with a call-to-action link to support the project.
  * Added an external “Apoyá el proyecto” link in the footer for quick access to the same donations page (opens in a new tab).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->