### PR TITLE
fix(csp): permitir el dominio real de archivos en el CSP

### DIFF
--- a/src/test/csp.test.ts
+++ b/src/test/csp.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// El CSP de vercel.json es el único lugar donde se declaran los hosts externos
+// que el sitio puede tocar. Un host mal escrito no rompe el build ni los tipos:
+// se ve recién en producción, como un recurso bloqueado en la consola.
+
+const FILES_HOST = 'https://files.exactamente.com.ar';
+
+const csp = (() => {
+  const config = JSON.parse(
+    readFileSync(new URL('../../vercel.json', import.meta.url), 'utf8'),
+  ) as {
+    headers: { headers: { key: string; value: string }[] }[];
+  };
+
+  const header = config.headers
+    .flatMap((rule) => rule.headers)
+    .find((h) => h.key === 'Content-Security-Policy');
+
+  if (!header) throw new Error('vercel.json no define Content-Security-Policy');
+
+  return Object.fromEntries(
+    header.value.split(';').map((directive) => {
+      const [name, ...sources] = directive.trim().split(/\s+/);
+      return [name, sources];
+    }),
+  ) as Record<string, string[] | undefined>;
+})();
+
+describe('CSP de producción', () => {
+  // El backend devuelve fileUrl apuntando a este host (R2 detrás de un dominio
+  // propio). El iframe de preview lo carga y el botón de descarga le hace fetch.
+  it('permite el host de archivos en frame-src', () => {
+    expect(csp['frame-src']).toContain(FILES_HOST);
+  });
+
+  it('permite el host de archivos en connect-src', () => {
+    expect(csp['connect-src']).toContain(FILES_HOST);
+  });
+
+  it('no referencia el dominio de archivos sin el .com', () => {
+    expect(JSON.stringify(csp)).not.toContain('https://files.exactamente.ar');
+  });
+
+  // El dominio está proxeado por Cloudflare, que inyecta el beacon de Web
+  // Analytics en cada respuesta. No lo sirve el repo, pero el CSP lo tiene que
+  // permitir igual o queda un error en la consola de todas las páginas.
+  it('permite el beacon de Cloudflare Web Analytics', () => {
+    expect(csp['script-src']).toContain('https://static.cloudflareinsights.com');
+    expect(csp['connect-src']).toContain('https://cloudflareinsights.com');
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -26,7 +26,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://api.exactamente.com.ar https://www.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://pub-111e72448f8d47019eb492c1626d1a88.r2.dev https://files.exactamente.ar; frame-src 'self' https://pub-111e72448f8d47019eb492c1626d1a88.r2.dev https://files.exactamente.ar; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://api.exactamente.com.ar https://cloudflareinsights.com https://www.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://pub-111e72448f8d47019eb492c1626d1a88.r2.dev https://files.exactamente.com.ar; frame-src 'self' https://pub-111e72448f8d47019eb492c1626d1a88.r2.dev https://files.exactamente.com.ar; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
         }
       ]
     }


### PR DESCRIPTION
## El bug

La vista previa de los recursos no carga. En consola:

```
Refused to load https://files.exactamente.com.ar/public/A2C1M4/....pdf
because it does not appear in the frame-src directive of the Content Security Policy.

Refused to load https://static.cloudflareinsights.com/beacon.min.js/...
because it does not appear in the script-src directive of the Content Security Policy.
```

## Root cause

El CSP de `vercel.json` listaba `https://files.exactamente.ar` — **sin el `.com`**. Ese dominio no resuelve. El backend devuelve `fileUrl` apuntando a `https://files.exactamente.com.ar`, verificado contra producción:

```
"fileUrl": "https://files.exactamente.com.ar/public/A2C1M3/....pdf"
```

O sea el host real nunca estuvo permitido. Además del iframe de preview, esto también rompía la descarga: `CardResource.tsx` le hace `fetch(fileUrl)` y `connect-src` tenía el mismo typo.

El typo estaba copiado en el `.env.example` del backend → exactamente-ar/exactamente-backend#13.

## Cambios

- `frame-src` y `connect-src`: `files.exactamente.ar` → `files.exactamente.com.ar`
- `script-src`: `+ https://static.cloudflareinsights.com`, `connect-src`: `+ https://cloudflareinsights.com` — el dominio está proxeado por Cloudflare (responde con `cf-ray`), que inyecta el beacon de Web Analytics en cada respuesta. No lo sirve este repo pero el CSP lo tiene que permitir igual.
- `src/test/csp.test.ts`: parsea el CSP y valida los hosts. `vercel.json` no lo toca ni el typecheck ni el build, así que un typo ahí solo se ve en producción — que es justo lo que pasó. Escrito antes del fix, falló 3/3.

## Verificación

`pnpm test` (24/24), `typecheck`, `lint` y `format:check` en verde.

⚠️ El CSP son headers de Vercel: **no se puede verificar en local**. Hay que confirmarlo en el preview deploy — abrir un recurso, que el iframe cargue y que la consola esté limpia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Content Security Policy settings to correctly allow file access and embedding.
  * Enabled required Cloudflare Web Analytics scripts and connections.
  * Removed an outdated file-host address from the security policy.

* **Tests**
  * Added automated checks to verify the production security policy includes the required trusted sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->