### PR TITLE
feat(resource): hacer que las descargas pasen por el backend

### DIFF
--- a/src/features/resource/components/CardResource.test.tsx
+++ b/src/features/resource/components/CardResource.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CardResource from './CardResource';
+
+/**
+ * El botón de descargar tiene que pasar por el backend.
+ *
+ * Bajando el archivo directo de R2 la descarga no se cuenta: `download_count`
+ * solo lo incrementa `GET /resources/:id/download`. Es toda la razón de ser de
+ * estos tests.
+ */
+
+const props = {
+  id: 'abc-123',
+  title: 'Parcial 1 - Álgebra',
+  fileUrl: 'https://files.exactamente.com.ar/public/A1C1M1/uuid.pdf',
+  type: 'parcial',
+  subtype: null,
+  examYear: 2024,
+  examMonth: 6,
+  topic: null,
+  mostRecent: false,
+};
+
+let assign: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  assign = vi.fn();
+  vi.stubGlobal('location', { ...window.location, assign });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('CardResource — descarga', () => {
+  it('navega al endpoint del backend, no al archivo de R2', async () => {
+    render(<CardResource {...props} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /descargar/i }));
+
+    expect(assign).toHaveBeenCalledTimes(1);
+    expect(assign.mock.calls[0][0]).toContain('/api/v1/resources/abc-123/download');
+  });
+
+  it('no toca la URL pública de R2 al descargar', async () => {
+    render(<CardResource {...props} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /descargar/i }));
+
+    // Si esto falla, la descarga volvió a ir directo al bucket y dejó de contar.
+    expect(assign.mock.calls[0][0]).not.toContain('files.exactamente.com.ar');
+  });
+
+  /**
+   * El `fetch` con fallback que había antes contaba dos veces cuando el redirect
+   * se bloqueaba: el intento contaba +1 y el `catch` navegaba al mismo endpoint,
+   * que contaba +1 otra vez.
+   */
+  it('no hace fetch: un solo impacto por click', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    render(<CardResource {...props} />);
+    await userEvent.click(screen.getByRole('button', { name: /descargar/i }));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('la preview sigue usando el archivo directo, que no cuenta como descarga', async () => {
+    render(<CardResource {...props} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Vista Previa' }));
+
+    const iframe = document.querySelector('iframe');
+    expect(iframe?.getAttribute('src')).toContain('files.exactamente.com.ar');
+    expect(assign).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/resource/components/CardResource.tsx
+++ b/src/features/resource/components/CardResource.tsx
@@ -6,8 +6,10 @@ import IconVisibility from '@/shared/components/icons/react/IconVisibility';
 import IconVisibilityOff from '@/shared/components/icons/react/IconVisibilityOff';
 import HeaderCardResource from './HeaderCardResource';
 import { usePreview } from '@/features/resource/hooks/usePreview';
+import { getResourceDownloadUrl } from '@/shared/services/api';
 
 interface Props {
+  id: string;
   title: string;
   fileUrl: string;
   type: string;
@@ -19,6 +21,7 @@ interface Props {
 }
 
 const CardResource: React.FC<Props> = ({
+  id,
   title,
   fileUrl,
   type,
@@ -31,7 +34,6 @@ const CardResource: React.FC<Props> = ({
   const { previewOpen, iframeLoaded, iframeRef, togglePreview, handleIframeLoad } =
     usePreview(fileUrl);
 
-  const [downloading, setDownloading] = useState(false);
   const [fullscreenOpen, setFullscreenOpen] = useState(false);
   const closeBtnRef = useRef<HTMLButtonElement>(null);
 
@@ -50,39 +52,23 @@ const CardResource: React.FC<Props> = ({
     };
   }, [fullscreenOpen]);
 
-  const getDownloadName = useCallback(() => {
-    const base = title?.trim() || 'recurso';
-    return /\.pdf$/i.test(base) ? base : `${base}.pdf`;
-  }, [title]);
-
-  const handleDownload = useCallback(async () => {
-    if (!fileUrl || downloading) return;
-    setDownloading(true);
-    try {
-      const res = await fetch(fileUrl);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const blob = await res.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = getDownloadName();
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      setTimeout(() => URL.revokeObjectURL(url), 0);
-    } catch {
-      const a = document.createElement('a');
-      a.href = fileUrl;
-      a.download = getDownloadName();
-      a.target = '_blank';
-      a.rel = 'noopener noreferrer';
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-    } finally {
-      setDownloading(false);
-    }
-  }, [fileUrl, downloading, getDownloadName]);
+  /**
+   * Navegación directa al endpoint del backend, que cuenta la descarga y
+   * redirige al archivo.
+   *
+   * Deliberadamente NO es un `fetch`. El backend responde un 302 hacia R2, y un
+   * fetch redirigido cross-origin manda `Origin: null`, así que queda sujeto a
+   * la política CORS del bucket. Peor: con el patrón anterior de fetch + catch
+   * que navegaba de fallback, un redirect bloqueado contaba la descarga DOS
+   * veces — una en el fetch y otra en el fallback.
+   *
+   * El costo es que se pierde el spinner de "Descargando…", porque la
+   * navegación se la lleva el navegador. El nombre del archivo no se pierde: lo
+   * pone el backend con Content-Disposition.
+   */
+  const handleDownload = useCallback(() => {
+    window.location.assign(getResourceDownloadUrl(id));
+  }, [id]);
 
   return (
     <div className='flex flex-col bg-gradient-to-br from-zinc-900/90 to-zinc-950/95 border border-zinc-800/60 rounded-xl hover:border-zinc-700/80 transition-all duration-300 group overflow-hidden'>
@@ -141,15 +127,13 @@ const CardResource: React.FC<Props> = ({
           <div className='flex gap-3 items-center flex-col sm:flex-row w-full sm:w-min'>
             <button
               onClick={handleDownload}
-              disabled={!fileUrl || downloading}
+              disabled={!fileUrl}
               className='group/download cursor-pointer w-full sm:w-max text-white font-bold flex items-center justify-center gap-2 px-6 py-3 rounded-xl transition-all duration-300 hover:scale-105 active:scale-95 gradient-border disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:active:scale-100'
             >
-              {downloading ? (
-                <div className='w-5 h-5 border-2 border-white/40 border-t-white rounded-full animate-spin' />
-              ) : (
-                <IconDownload size={20} className='fill-white' />
-              )}
-              {downloading ? 'Descargando...' : 'Descargar'}
+              {/* Sin spinner: la descarga es una navegación, así que el
+                  navegador se lleva la página y el estado no llega a verse. */}
+              <IconDownload size={20} className='fill-white' />
+              Descargar
             </button>
 
             <button

--- a/src/features/resource/components/ListOfResources.tsx
+++ b/src/features/resource/components/ListOfResources.tsx
@@ -58,6 +58,7 @@ const ListOfResources: React.FC<Props> = ({ resources, type, error, loading = tr
           {sorted.map((resource, i) => (
             <CardResource
               key={resource.id}
+              id={resource.id}
               title={resource.title}
               fileUrl={resource.fileUrl}
               type={type}

--- a/src/shared/services/api.ts
+++ b/src/shared/services/api.ts
@@ -188,6 +188,20 @@ export function mapResource(backend: BackendResource): ResourceFetch {
   };
 }
 
+/**
+ * URL para **bajar** un recurso. Distinta de `fileUrl`, que es para **verlo**.
+ *
+ * `fileUrl` apunta directo a R2 y no pasa por la API, así que bajar desde ahí
+ * no incrementa `downloadCount`. Este endpoint cuenta la descarga y después
+ * redirige (302) al archivo, con el nombre del recurso en vez del uuid.
+ *
+ * Vive acá y no en el componente porque `BASE_URL` es privado del módulo y la
+ * regla del repo es que ninguna URL de la API se arme afuera de este archivo.
+ */
+export function getResourceDownloadUrl(id: string): string {
+  return `${BASE_URL}/api/v1/resources/${id}/download`;
+}
+
 export function getCareers(params?: { facultyId?: string }): Promise<ApiResult<Career[]>> {
   const url = new URL(`${BASE_URL}/api/v1/careers`);
   if (params?.facultyId) url.searchParams.set('facultyId', params.facultyId);

--- a/src/shared/types/api.d.ts
+++ b/src/shared/types/api.d.ts
@@ -264,6 +264,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/resources/{id}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Descargar un recurso
+         * @description Incrementa `downloadCount` y redirige (302) al archivo. **Es la única vía que cuenta descargas**: linkear directo a `fileUrl` no cuenta nada. `fileUrl` es para *ver* el PDF (preview, iframe); esta ruta es para *bajarlo*.
+         */
+        get: operations["getApiV1ResourcesByIdDownload"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/resources/check-duplicate": {
         parameters: {
             query?: never;
@@ -641,6 +661,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/stats/activity": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Actividad en el tiempo
+         * @description Recursos creados y publicados por bucket. La serie no tiene huecos: los buckets sin actividad vienen en 0. Los buckets se agrupan en hora argentina.
+         */
+        get: operations["getApiV1AdminStatsActivity"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/stats/rankings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Rankings de colaboradores y recursos
+         * @description `topUploaders` respeta la ventana `days`. `topResources` NO: `download_count` es un escalar sin fecha, así que el ranking de descargas es siempre histórico.
+         */
+        get: operations["getApiV1AdminStatsRankings"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/stats/moderation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Salud de la cola de moderación
+         * @description Lead time (horas entre subida y publicación) sobre la ventana `days`, más la antigüedad de la cola actual de pendientes — que es estado presente y no depende de `days`.
+         */
+        get: operations["getApiV1AdminStatsModeration"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -913,6 +993,71 @@ export interface components {
                 faculties: number;
                 universities: number;
             };
+        };
+        /** @enum {string} */
+        StatsGranularity: "day" | "week";
+        ActivityPoint: {
+            /** @description Inicio del bucket, YYYY-MM-DD, en America/Argentina/Buenos_Aires */
+            date: string;
+            /** @description Recursos creados en el bucket (created_at) */
+            uploads: number;
+            /** @description Recursos publicados en el bucket (published_at) */
+            publications: number;
+        };
+        AdminActivity: {
+            granularity: components["schemas"]["StatsGranularity"];
+            /** @description Primer bucket, YYYY-MM-DD */
+            from: string;
+            /** @description Último bucket, YYYY-MM-DD */
+            to: string;
+            /** @description Serie sin huecos: los buckets sin actividad vienen en 0, no ausentes */
+            points: components["schemas"]["ActivityPoint"][];
+        };
+        TopUploader: {
+            userId: string;
+            displayName: string;
+            /** @description Recursos subidos en la ventana, en cualquier estado */
+            total: number;
+            /** @description De esos, cuántos terminaron publicados */
+            published: number;
+        };
+        TopResource: {
+            id: string;
+            title: string;
+            subjectTitle: string | null;
+            type: components["schemas"]["ResourceType"];
+            downloadCount: number;
+        };
+        AdminRankings: {
+            days: number;
+            topUploaders: components["schemas"]["TopUploader"][];
+            /** @description Histórico completo. `download_count` es un escalar sin fecha, así que `days` NO aplica acá */
+            topResources: components["schemas"]["TopResource"][];
+        };
+        /** @description Horas entre que un recurso se sube y se publica. Con `sample: 0` los tres percentiles son null y no 0: "no hubo datos" y "tardó cero" no son lo mismo */
+        ModerationLeadTime: {
+            /** @description Recursos publicados en la ventana */
+            sample: number;
+            avgHours: number | null;
+            p50Hours: number | null;
+            p90Hours: number | null;
+        };
+        /** @description Antigüedad de la cola de moderación. No depende de `days`: es el estado actual */
+        PendingQueueAge: {
+            total: number;
+            under24h: number;
+            /** @description Entre 1 y 3 días */
+            d1to3: number;
+            /** @description Entre 3 y 7 días */
+            d3to7: number;
+            /** @description Más de 7 días */
+            over7d: number;
+            oldestCreatedAt: string | null;
+        };
+        AdminModeration: {
+            days: number;
+            leadTime: components["schemas"]["ModerationLeadTime"];
+            queue: components["schemas"]["PendingQueueAge"];
         };
         ErrorResponse: {
             /** @description Mensaje descriptivo, apto para mostrar al usuario */
@@ -1442,6 +1587,50 @@ export interface operations {
                         error: string;
                     };
                 };
+            };
+            /** @description Recurso no encontrado */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Mensaje descriptivo, apto para mostrar al usuario */
+                        error: string;
+                    };
+                };
+            };
+            /** @description Rate limit excedido */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Mensaje descriptivo, apto para mostrar al usuario */
+                        error: string;
+                    };
+                };
+            };
+        };
+    };
+    getApiV1ResourcesByIdDownload: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Redirección temporal al archivo */
+            302: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Recurso no encontrado */
             404: {
@@ -4020,6 +4209,191 @@ export interface operations {
                             faculties: number;
                             universities: number;
                         };
+                    };
+                };
+            };
+            /** @description Sin token o token inválido */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Mensaje descriptivo, apto para mostrar al usuario */
+                        error: string;
+                    };
+                };
+            };
+            /** @description Rol insuficiente */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Mensaje descriptivo, apto para mostrar al usuario */
+                        error: string;
+                    };
+                };
+            };
+        };
+    };
+    getApiV1AdminStatsActivity: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Serie temporal */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        granularity: components["schemas"]["StatsGranularity"];
+                        /** @description Primer bucket, YYYY-MM-DD */
+                        from: string;
+                        /** @description Último bucket, YYYY-MM-DD */
+                        to: string;
+                        /** @description Serie sin huecos: los buckets sin actividad vienen en 0, no ausentes */
+                        points: components["schemas"]["ActivityPoint"][];
+                    };
+                };
+            };
+            /** @description Validación fallida */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Mensaje descriptivo, apto para mostrar al usuario */
+                        error: string;
+                    };
+                };
+            };
+            /** @description Sin token o token inválido */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Mensaje descriptivo, apto para mostrar al usuario */
+                        error: string;
+                    };
+                };
+            };
+            /** @description Rol insuficiente */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Mensaje descriptivo, apto para mostrar al usuario */
+                        error: string;
+                    };
+                };
+            };
+        };
+    };
+    getApiV1AdminStatsRankings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Rankings */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        days: number;
+                        topUploaders: components["schemas"]["TopUploader"][];
+                        /** @description Histórico completo. `download_count` es un escalar sin fecha, así que `days` NO aplica acá */
+                        topResources: components["schemas"]["TopResource"][];
+                    };
+                };
+            };
+            /** @description Validación fallida */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Mensaje descriptivo, apto para mostrar al usuario */
+                        error: string;
+                    };
+                };
+            };
+            /** @description Sin token o token inválido */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Mensaje descriptivo, apto para mostrar al usuario */
+                        error: string;
+                    };
+                };
+            };
+            /** @description Rol insuficiente */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Mensaje descriptivo, apto para mostrar al usuario */
+                        error: string;
+                    };
+                };
+            };
+        };
+    };
+    getApiV1AdminStatsModeration: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Moderación */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        days: number;
+                        leadTime: components["schemas"]["ModerationLeadTime"];
+                        queue: components["schemas"]["PendingQueueAge"];
+                    };
+                };
+            };
+            /** @description Validación fallida */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Mensaje descriptivo, apto para mostrar al usuario */
+                        error: string;
                     };
                 };
             };


### PR DESCRIPTION
## Qué es

Bajando el archivo directo de R2 la descarga **no se cuenta**: `download_count` solo lo incrementa `GET /resources/:id/download`, que se agregó en el backend. El botón "Descargar" pasa a apuntar ahí.

## ⚠️ Este es el único PR de la tanda que toca el sitio público

Cambia el botón Descargar de todas las páginas de recursos. Rollback de un click en Vercel, pero mientras tanto nadie baja nada si sale mal.

## Depende de

exactamente-backend#17 — **mergear primero**, o el endpoint no existe.

## Es una navegación, no un fetch

Deliberado. El backend responde un 302 hacia R2:

- **CORS tras redirect cross-origin.** Un `fetch` redirigido manda `Origin: null` y queda sujeto a la política CORS del bucket. Hoy funciona porque el fetch va directo a R2 con el `Origin` real.
- **Doble conteo.** El patrón anterior era `fetch` con un `catch` que navegaba de fallback. Si el fetch contaba +1 pero el redirect quedaba bloqueado, el fallback contaba **+1 otra vez**, de forma no determinística.

**Costo asumido:** se pierde el spinner de "Descargando…", porque la navegación se la lleva el navegador. **El nombre del archivo no se pierde** — lo pone el backend con `Content-Disposition`, con la extensión real (hay 27 `.jpg` en la base, herencia de la migración de Drive).

## Ver ≠ bajar

`fileUrl` se queda para la vista previa. Mandar el `<iframe>` por el endpoint contador inflaría el número. Hay un test para eso.

## Otros

- La URL se arma en `services/api.ts` y no en el componente: ahí vive `BASE_URL` y es la regla del repo.
- `ListOfResources` ahora pasa el `id` al card — ya venía en `ResourceFetch` pero se usaba solo como `key`.
- **`vercel.json` no se toca:** el CSP no restringe navegaciones top-level. `csp.test.ts` pasa igual.

## Verificación

TDD como pide el repo: los 4 tests escritos primero, vistos fallar, después la implementación.

- Cadena completa en Chrome contra el backend local: click → `/api/v1/resources/<id>/download` → 302 → URL firmada de R2.
- Suite: 28 tests, todos verdes.

## Pendiente de verificar en el preview

**Bajá un PDF de verdad y confirmá que llega con el nombre del recurso y no como `<uuid>`.** Es lo único que no pude probar localmente — las credenciales de R2 en dev son falsas, así que verifiqué que la URL firmada se arma bien pero no que Cloudflare respete `response-content-disposition`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource downloads now use a dedicated download endpoint, enabling download tracking and clearer handling of unavailable or rate-limited resources.
  * Added API support for administrative activity, ranking, and moderation statistics.
* **Bug Fixes**
  * Resource previews continue opening files directly without triggering a download.
  * Download actions no longer fetch files unnecessarily or expose direct storage URLs.
* **Tests**
  * Added coverage for resource download navigation and preview behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->